### PR TITLE
FFTS cmake improvements

### DIFF
--- a/cmake/FindFFTS.cmake
+++ b/cmake/FindFFTS.cmake
@@ -4,6 +4,7 @@ if(NOT LIBFFTS_FOUND)
   find_path(LIBFFTS_INCLUDE_DIR NAMES ffts.h
 	PATHS
 	${LIBFFTS_PKG_INCLUDE_DIRS}
+	include/ffts
 	/usr/include/ffts
 	/usr/local/include/ffts
 	$ENV{HOME}/.local/include/ffts

--- a/cmake/FindFFTS.cmake
+++ b/cmake/FindFFTS.cmake
@@ -9,7 +9,7 @@ if(NOT LIBFFTS_FOUND)
 	/usr/local/include/ffts
 	$ENV{HOME}/.local/include/ffts
   )
-  find_library(LIBFFTS_LIBRARIES NAMES ffts
+  find_library(LIBFFTS_LIBRARIES NAMES ffts libffts_static
 	PATHS
 	${LIBFFTS_PKG_LIBRARY_DIRS}
 	/usr/lib

--- a/cmake/FindFFTS.cmake
+++ b/cmake/FindFFTS.cmake
@@ -4,10 +4,12 @@ if(NOT LIBFFTS_FOUND)
   find_path(LIBFFTS_INCLUDE_DIR NAMES ffts.h
 	PATHS
 	${LIBFFTS_PKG_INCLUDE_DIRS}
+	/usr
+	/usr/local
+	$ENV{HOME}/.local
+
+	PATH_SUFFIXES
 	include/ffts
-	/usr/include/ffts
-	/usr/local/include/ffts
-	$ENV{HOME}/.local/include/ffts
   )
   find_library(LIBFFTS_LIBRARIES NAMES ffts libffts_static
 	PATHS


### PR DESCRIPTION
Provide the default include suffix path and alternative static library name for FFTS.

The existing cmake helper couldn't find FFTS when installed to system paths that weren't listed, and needed special handling under MinGW.
This should make it easier for distro maintainers to package scopehal in the future.